### PR TITLE
 Change avatar image to Zenia

### DIFF
--- a/src/components/data/config.json
+++ b/src/components/data/config.json
@@ -1,4 +1,4 @@
 {
  "botDelay": 1000,
- "botAvatar": "http://giftthecode.ca/assets/img/2017/charities/charity-reps/Sis_CharlotteEmpeyc.png"
+ "botAvatar": "http://sistering.org/wp-content/uploads/2017/04/2-SpeakersTours.jpg"
 }


### PR DESCRIPTION
The avatar image in the chat used to be Charlotte, but it should be Zenia as she is the volunteer coordinator.